### PR TITLE
Set project name for root command

### DIFF
--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -17,8 +17,8 @@ var _scaffoldCmd = &cobra.Command{
 		config := map[string]any{
 			"ModuleName":   "github.com/mshirdel/byteland",
 			"Port":         "9090",
-			"RootCMD":      projectRoot,
-			"RootCMDShort": projectRoot,
+			"RootCMD":      name,
+			"RootCMDShort": name,
 			"RunCMD":       "run",
 			"RunCMDShort":  "run project",
 		}

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -17,8 +17,8 @@ var _scaffoldCmd = &cobra.Command{
 		config := map[string]any{
 			"ModuleName":   "github.com/mshirdel/byteland",
 			"Port":         "9090",
-			"RootCMD":      "sandbox",
-			"RootCMDShort": "sandbox",
+			"RootCMD":      projectRoot,
+			"RootCMDShort": projectRoot,
 			"RunCMD":       "run",
 			"RunCMDShort":  "run project",
 		}

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -2,33 +2,43 @@ package cmd
 
 import (
 	"fmt"
+	"io/fs"
 	"path/filepath"
 
 	"github.com/mshirdel/scaffoldgo/internal"
+	"github.com/mshirdel/scaffoldgo/internal/assets"
 	"github.com/spf13/cobra"
 )
+
+var (
+	moduleName  string
+	projectName string
+	port        int
+)
+
+func init() {
+	_scaffoldCmd.Flags().StringVarP(&moduleName, "module", "m", "", "Module name like: gitbun.com/name/project_name ")
+	_scaffoldCmd.Flags().StringVarP(&projectName, "name", "n", "", "Project name")
+	_scaffoldCmd.Flags().IntVarP(&port, "port", "p", 8080, "Web server port")
+}
 
 var _scaffoldCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a new go project",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		name := args[0]
-		projectRoot := filepath.Join(".", name)
+		projectRoot := filepath.Join(".", projectName)
 		config := map[string]any{
-			"ModuleName":   "github.com/mshirdel/byteland",
-			"Port":         "9090",
-			"RootCMD":      name,
-			"RootCMDShort": name,
+			"ModuleName":   moduleName,
+			"Port":         port,
+			"RootCMDShort": projectName,
+			"RootCMD":      projectName,
 			"RunCMD":       "run",
 			"RunCMDShort":  "run project",
 		}
 
-		files := map[string]string{
-			filepath.Join(projectRoot, "", "go.mod"):             "templates/gomod",
-			filepath.Join(projectRoot, "", "main.go"):            "templates/maingo",
-			filepath.Join(projectRoot, "configs", "config.yaml"): "templates/configs/config.yaml",
-			filepath.Join(projectRoot, "cmd", "root.go"):         "templates/cmd/rootgo",
-			filepath.Join(projectRoot, "cmd", "run.go"):          "templates/cmd/rungo",
+		files, err := collectFiles(projectRoot)
+		if err != nil {
+			fmt.Println(err)
 		}
 
 		for path, template := range files {
@@ -37,6 +47,31 @@ var _scaffoldCmd = &cobra.Command{
 
 		return nil
 	},
+}
+
+func collectFiles(projectRoot string) (map[string]string, error) {
+	files := make(map[string]string)
+
+	err := fs.WalkDir(assets.Templates, "templates", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+
+		relPath, err := filepath.Rel("templates", path)
+		if err != nil {
+			return err
+		}
+
+		dest := filepath.Join(projectRoot, relPath)
+
+		files[dest] = path
+		return nil
+	})
+
+	return files, err
 }
 
 func create(destPath, templatePath string, values map[string]any) {

--- a/internal/assets/templates/app/app.go
+++ b/internal/assets/templates/app/app.go
@@ -1,0 +1,62 @@
+package app
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"{{.ModuleName}}/config"
+)
+
+type Application struct {
+	configPath string
+	Cfg        *config.Config
+}
+
+func New(configPath string) *Application {
+	return &Application{
+		configPath: configPath,
+	}
+}
+
+func (app *Application) InitAll() error {
+	if err := app.InitConfig(); err != nil {
+		return err
+	}
+
+	// app.InitLogger()
+	//
+	// if err := app.InitTracer(); err != nil {
+	// 	return err
+	// }
+	//
+	// if err := app.InitAllDatabases(); err != nil {
+	// 	return err
+	// }
+	//
+	// app.InitAllRepositories()
+	// app.InitAllThirdParties()
+	// app.InitAllCache()
+	//
+	// if err := app.InitAllServices(); err != nil {
+	// 	return err
+	// }
+
+	return nil
+}
+
+func (app *Application) InitConfig() (err error) {
+	if app.Cfg != nil {
+		return
+	}
+
+	app.Cfg, err = config.InitViper(app.configPath)
+	if err != nil {
+		return fmt.Errorf("config initialization failed: %w", err)
+	}
+
+	return
+}
+
+func (app *Application) Shutdown() {
+	logrus.Info("shutting down application...")
+}

--- a/internal/assets/templates/app/http/controller/controller.go
+++ b/internal/assets/templates/app/http/controller/controller.go
@@ -1,0 +1,70 @@
+package controller
+
+import (
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/labstack/echo"
+	"{{.ModuleName}}/app"
+)
+
+type Controller struct {
+	app                   *app.Application
+	healthCheckController *HealthCheckController
+}
+
+func NewController(app *app.Application) *Controller {
+	return &Controller{
+		app:                   app,
+		healthCheckController: NewHealthCheckController(app),
+	}
+}
+
+func (c *Controller) Routes() *echo.Echo {
+	router := c.initEcho()
+
+	// initGeneralMiddlewares(router, &c.app.Cfg.HTTP, &c.app.Cfg.Locale)
+
+	router.GET("/", c.healthCheckController.Index)
+
+	health := router.Group("/healthz")
+	{
+		health.GET("/liveness", c.healthCheckController.Liveness)
+		health.GET("/readiness", c.healthCheckController.Readiness)
+	}
+
+	if router.Debug {
+		printRoutes(router.Routes())
+	}
+
+	return router
+}
+
+func (c *Controller) initEcho() *echo.Echo {
+	r := echo.New()
+	r.Debug = c.app.Cfg.Logging.Level == "debug"
+	// r.Validator = validator.New()
+	// r.HTTPErrorHandler = HTTPErrorHandler
+
+	return r
+}
+
+func printRoutes(routes []*echo.Route) {
+	var maxMethodLength, maxPathLength float64
+	for _, r := range routes {
+		maxMethodLength = math.Max(maxMethodLength, float64(len(r.Method)))
+		maxPathLength = math.Max(maxPathLength, float64(len(r.Path)))
+	}
+
+	fmt.Printf("\nRegistered http routes:\n")
+
+	for _, r := range routes {
+		// do not print middlewares
+		if strings.HasPrefix(r.Name, "github.com/labstack/echo") {
+			continue
+		}
+
+		fmt.Printf("%-*v %-*v --> %v\n", int(maxMethodLength), r.Method, int(maxPathLength), r.Path, r.Name)
+	}
+}

--- a/internal/assets/templates/app/http/controller/health.go
+++ b/internal/assets/templates/app/http/controller/health.go
@@ -1,0 +1,30 @@
+package controller
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo"
+	"{{.ModuleName}}/app"
+)
+
+type HealthCheckController struct {
+	app *app.Application
+}
+
+func NewHealthCheckController(app *app.Application) *HealthCheckController {
+	return &HealthCheckController{
+		app: app,
+	}
+}
+
+func (h *HealthCheckController) Index(c echo.Context) error {
+	return c.String(http.StatusOK, "OK")
+}
+
+func (h *HealthCheckController) Liveness(c echo.Context) error {
+	return c.NoContent(http.StatusOK)
+}
+
+func (h *HealthCheckController) Readiness(c echo.Context) error {
+	return c.NoContent(http.StatusOK)
+}

--- a/internal/assets/templates/app/http/server.go
+++ b/internal/assets/templates/app/http/server.go
@@ -1,0 +1,53 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"{{.ModuleName}}/app"
+	"{{.ModuleName}}/app/http/controller"
+)
+
+type HTTPServer struct {
+	app    *app.Application
+	server *http.Server
+}
+
+func NewHTTPServer(app *app.Application) *HTTPServer {
+	controller := controller.NewController(app)
+
+	return &HTTPServer{
+		app: app,
+		server: &http.Server{
+			Addr:              app.Cfg.Server.Address,
+			ReadTimeout:       app.Cfg.Server.ReadTimeout,
+			ReadHeaderTimeout: app.Cfg.Server.ReadTimeout,
+			WriteTimeout:      app.Cfg.Server.WriteTimeout,
+			IdleTimeout:       app.Cfg.Server.IdleTimeout,
+			Handler:           controller.Routes(),
+		},
+	}
+}
+
+func (h *HTTPServer) Start(_ context.Context) {
+	logrus.Infof("starting http server on: %s", h.app.Cfg.Server.Address)
+
+	if err := h.server.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+		logrus.Fatalf("failed starting http server: %v", err)
+	}
+}
+
+func (h *HTTPServer) Shutdown(ctx context.Context) {
+	logrus.Info("shutting down http server...")
+
+	// TODO: make it configurable
+	deadline, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	if err := h.server.Shutdown(deadline); err != nil {
+		logrus.Errorf("failed shutting down http server: %s", err)
+	}
+}

--- a/internal/assets/templates/cmd/root.go
+++ b/internal/assets/templates/cmd/root.go
@@ -7,8 +7,8 @@ import (
 
 var (
 	_rootCMD = cobra.Command{
-		Use:   "{{.RootCMD}}",
-		Short: "{{.RootCMDShort}}",
+		Use:   "{{.projectName}}",
+		Short: "{{.projectName}}",
 	}
 
 	_configPath string
@@ -16,6 +16,7 @@ var (
 
 func init() {
 	_rootCMD.AddCommand(_runCmd)
+	_rootCMD.AddCommand(_serve)
 }
 
 func Execute() {

--- a/internal/assets/templates/cmd/run.go
+++ b/internal/assets/templates/cmd/run.go
@@ -7,8 +7,8 @@ import (
 )
 
 var _runCmd = &cobra.Command{
-	Use:   "{{.RunCMD}}",
-	Short: "{{.RunCMDShort}}",
+	Use:   "run",
+	Short: "run project",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		run()
 		return nil

--- a/internal/assets/templates/cmd/serve.go
+++ b/internal/assets/templates/cmd/serve.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/spf13/cobra"
+	"{{.ModuleName}}/app"
+	api "{{.ModuleName}}/app/http"
+)
+
+var _serve = &cobra.Command{
+	Use:   "serve",
+	Short: "serve APIs",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		app := app.New(_configPath)
+		if err := app.InitAll(); err != nil {
+			return err
+		}
+		defer app.Shutdown()
+
+		ctx := context.Background()
+		server := api.NewHTTPServer(app)
+		defer server.Shutdown(ctx)
+		go server.Start(ctx)
+
+		<-handleInterrupts()
+		return nil
+	},
+}
+
+func handleInterrupts() <-chan os.Signal {
+	signals := make(chan os.Signal, 1)
+	signal.Notify(
+		signals,
+		syscall.SIGTERM,
+		syscall.SIGINT,
+	)
+
+	return signals
+}

--- a/internal/assets/templates/config/builtin.go
+++ b/internal/assets/templates/config/builtin.go
@@ -1,0 +1,11 @@
+package config
+
+var _builtinConfig = `
+server:
+  address: "0.0.0.0:{{.Port}}"
+  idle-timeout: 2m
+  read-timeout: 1s
+  write-timeout: 3s
+logging:
+  level: debug
+`

--- a/internal/assets/templates/config/config.go
+++ b/internal/assets/templates/config/config.go
@@ -1,0 +1,70 @@
+package config
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/go-playground/validator/v10"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+)
+
+type Config struct {
+	Server  Server  `mapstructure:"server" validate:"required"`
+	Logging Logging `mapstructure:"logging" validate:"required"`
+}
+
+type Server struct {
+	Address      string        `mapstructure:"address" validate:"required,hostname_port"`
+	ReadTimeout  time.Duration `mapstructure:"read-timeout" validate:"required"`
+	WriteTimeout time.Duration `mapstructure:"write-timeout" validate:"required"`
+	IdleTimeout  time.Duration `mapstructure:"idle-timeout" validate:"required"`
+}
+
+type Logging struct {
+	Level string `mapstructure:"level" validate:"required,lowercase,oneof=trace debug info warn warning error fatal panic"`
+}
+
+const _envPrefix = "{{.ModuleName}}"
+
+func InitViper(configPath string) (*Config, error) {
+	var c Config
+
+	v := viper.New()
+	v.SetConfigType("yaml")
+
+	if err := v.ReadConfig(bytes.NewReader([]byte(_builtinConfig))); err != nil {
+		return nil, fmt.Errorf("error loading default configs: %w", err)
+	}
+
+	v.SetConfigFile(configPath)
+	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
+	v.SetEnvPrefix(_envPrefix)
+	v.AutomaticEnv()
+
+	switch err := v.MergeInConfig(); err.(type) {
+	case nil:
+	case *os.PathError:
+		logrus.Infof("config file (%s) not found, Using defaults and environment variables", configPath)
+	default:
+		logrus.Warnf("failed to load config file: %s", err)
+	}
+
+	if err := v.UnmarshalExact(&c); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal config into struct: %w", err)
+	}
+
+	if err := c.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid configuration: %w", err)
+	}
+
+	return &c, nil
+}
+
+func (c *Config) Validate() error {
+	return validator.New().Struct(c)
+}

--- a/internal/assets/templates/configs/config.yaml
+++ b/internal/assets/templates/configs/config.yaml
@@ -1,3 +1,0 @@
-http:
-  address: 'localhost'
-  port: {{.Port}}

--- a/internal/assets/templates/gomod
+++ b/internal/assets/templates/gomod
@@ -3,7 +3,43 @@ module {{.ModuleName}}
 go 1.24
 
 require (
-	github.com/labstack/echo v3.3.10+incompatible
+	github.com/go-playground/validator v9.31.0+incompatible
+	github.com/go-playground/validator/v10 v10.27.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.9.1
+	github.com/spf13/viper v1.20.1
+)
+
+require (
+	github.com/labstack/gommon v0.4.2 // indirect
+	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/valyala/bytebufferpool v1.0.0 // indirect
+	github.com/valyala/fasttemplate v1.2.2 // indirect
+	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
+)
+
+require (
+	github.com/fsnotify/fsnotify v1.8.0 // indirect
+	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
+	github.com/go-playground/locales v0.14.1 // indirect
+	github.com/go-playground/universal-translator v0.18.1 // indirect
+	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/labstack/echo v3.3.10+incompatible
+	github.com/leodido/go-urn v1.4.0 // indirect
+	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
+	github.com/sagikazarmark/locafero v0.7.0 // indirect
+	github.com/sourcegraph/conc v0.3.0 // indirect
+	github.com/spf13/afero v1.12.0 // indirect
+	github.com/spf13/cast v1.7.1 // indirect
+	github.com/spf13/pflag v1.0.6 // indirect
+	github.com/subosito/gotenv v1.6.0 // indirect
+	go.uber.org/atomic v1.9.0 // indirect
+	go.uber.org/multierr v1.9.0 // indirect
+	golang.org/x/crypto v0.33.0 // indirect
+	golang.org/x/net v0.34.0 // indirect
+	golang.org/x/sys v0.30.0 // indirect
+	golang.org/x/text v0.22.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/assets/templates/main.go
+++ b/internal/assets/templates/main.go
@@ -5,5 +5,5 @@ import (
 )
 
 func main() {
-  cmd.Execute()
+	cmd.Execute()
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project scaffolding is now name-driven with flags for module, project name, and port.
  * Added a scaffolded application bootstrap, configurable server, and HTTP server with health endpoints (/, /healthz/liveness, /healthz/readiness).
  * New serve command to run the API with graceful shutdown.

* **Refactor**
  * Command usage text and template discovery made dynamic to auto-detect templates and project name.

* **Config**
  * Built-in default YAML config, environment overrides, and validation for server and logging settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->